### PR TITLE
Fix git commands for staging and pushing changes

### DIFF
--- a/sync-repo.sh
+++ b/sync-repo.sh
@@ -1,13 +1,12 @@
 # This bash script uses git to synchronize changes between the local and remote GitHub repository.
-# TODO: Ask copilot chat to review the script and suggest improvements.
 
-git add .
+git stage .
 
 git commit -m "Updated"
 
 git pull origin main
 
-git push 
+git push origin main
 
 # Check if the push was successful
 if [ $? -eq 0 ]; then


### PR DESCRIPTION
This pull request updates the `sync-repo.sh` script to improve consistency and clarity in git command usage.

Improvements to git workflow:

* Replaced `git add .` with `git stage .` for staging changes, which is a more explicit command.
* Changed `git push` to `git push origin main` to specify the branch being pushed, ensuring clarity and preventing accidental pushes to unintended branches.